### PR TITLE
Show content for events without primary color

### DIFF
--- a/pretalx_lower_thirds/templates/pretalx_lower_thirds/lower_thirds.html
+++ b/pretalx_lower_thirds/templates/pretalx_lower_thirds/lower_thirds.html
@@ -12,7 +12,7 @@
         <link rel="stylesheet" href="{% static "pretalx_lower_thirds/frontend.css" %}" />
         <style type="text/css">
             #box {
-                background-color: {{ request.event.primary_color }};
+                background-color: {{ request.event.primary_color|default:"#3aa57c" }};
             }
         </style>
     </head>


### PR DESCRIPTION
Currently, this turns into white-on-white.
